### PR TITLE
Update to support Pro Display XDR

### DIFF
--- a/BrightIntosh/BrightnessManager.swift
+++ b/BrightIntosh/BrightnessManager.swift
@@ -98,7 +98,7 @@ func getBuiltInScreen() -> NSScreen? {
     for screen in NSScreen.screens {
         let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
         let displayId: CGDirectDisplayID = screenNumber as! CGDirectDisplayID
-        if (CGDisplayIsBuiltin(displayId) != 0) {
+        if (CGDisplayIsBuiltin(displayId) != 0 || screen.localizedName == "Pro Display XDR") {
             return screen
         }
     }


### PR DESCRIPTION
Issue #55

Worth noting that this works on both the Pro Display and Main Display when they're set to mirror eachother. If not set to mirror eachother, it works only on the display in the NSScreen.screens array that is first identified to be compatible.

A print statement added to a copy of the getBuiltInScreen() method's loop gives the following output when connected to both displays:

`print("displayID: \(displayId), screen number: \(screenNumber!), name: \(screen.localizedName)") `
```
displayID: 5, screen number: 5, name: Pro Display XDR
displayID: 1, screen number: 1, name: Built-in Retina Display
```
and gives this output when the laptop clamshell is closed or when the displays are set to mirror eachother with the Pro Display as the main display:

```
displayID: 5, screen number: 5, name: Pro Display XDR
```
and gives this output when the laptop display is selected as the display to be optimized for:
```
displayID: 1, screen number: 1, name: Built-in Retina Display
```
The change I made is minimal but a more complete implementation is possible with using the localizedName property to distinguish between screens, and support multiple screens at the same time for users with Multiple Pro Display XDR or Pro Display and Open XDR screen laptop.